### PR TITLE
Removed css classes causing images to be scaled too small in Firefox

### DIFF
--- a/TenkiAme/Views/Home/Index.cshtml
+++ b/TenkiAme/Views/Home/Index.cshtml
@@ -95,13 +95,13 @@
                             @weatherHour.Time.ToString("htt")
                         </div>
                         <div class="justify-centre margin-top margin-left margin-right">
-                            <img src="/images/Raindrops-Transparent.png" class="justify-centre margin-left margin-right" style="height: 100%; width:100%;" />
+                            <img src="/images/Raindrops-Transparent.png" class="justify-centre" style="height: 100%; width:100%;" />
                          </div>
                         <div id="@rainDivId" class="justify-centre margin-top margin-left margin-right">
                             @weatherHour.GetFormattedRainfall()
                         </div>
                         <div class="justify-centre margin-top margin-left margin-right">
-                            <img src="/images/Orange-Thermometer-Transparent.png" class="justify-centre margin-left margin-right" style="height: 100%; width:100%;" />
+                            <img src="/images/Orange-Thermometer-Transparent.png" class="justify-centre" style="height: 100%; width:100%;" />
                         </div>
                         <div id="@tempDivId" class="justify-centre margin-top margin-left margin-right" style="">
                             @weatherHour.GetFormattedTemperature()


### PR DESCRIPTION
Removed css classes causing images to be scaled too small in browsers using the Gecko rendering engine.